### PR TITLE
fix: use the status of the most recently created node if there are multiple with the same hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +950,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2282,6 +2297,7 @@ dependencies = [
  "axum-test",
  "chrono",
  "env_logger",
+ "itertools",
  "log",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4.42"
 anyhow = "1.0.100"
 tower-http = { version = "0.6.8", features = ["fs"] }
 askama_escape = "0.15.1"
+itertools = "0.14.0"
 
 [dev-dependencies]
 axum-test = "18.5.0"


### PR DESCRIPTION
### Summary
Nomad api can return multiple nodes with the same hostname. A user may shutdown their node and restart it which could show up as a separate node.

Previously if multiple nodes had duplicate hostnames, the UI would show the status of the last same-named node in the api response. Now it shows the status of the most recently created same-named node.

### TODO:

- [x] All code changes are reflected in docs, including module-level docs


_Note that all commits in a PR must follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0) before it can be merged, as these are used to generate the changelog_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic deduplication of Nomad nodes by hostname, retaining only the most recently created/updated entry.

* **Tests**
  * Test suite converted to data-driven server responses; added a smoke test verifying duplicate removal.

* **Chores**
  * Added a new build dependency to support the deduplication logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->