### PR TITLE
ci: add workflow to deploy app on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,11 @@
-name: Publish Docker Image
+name: Publish and Deploy
 
 on:
   push:
     branches: [ main ]
 
 jobs:
-  docker-publish:
+  publish-and-deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,3 +42,13 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Trigger DigitalOcean deployment
+      run: |
+        curl -sf -X POST \
+          --connect-timeout 10 \
+          --max-time 30 \
+          "https://api.digitalocean.com/v2/apps/${{ secrets.DO_APP_ID }}/deployments" \
+          -H "Authorization: Bearer ${{ secrets.DO_API_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          -d '{"force_build": true}'

--- a/infra/main.go
+++ b/infra/main.go
@@ -26,11 +26,12 @@ func main() {
 						Name:             pulumi.String("web"),
 						InstanceCount:    pulumi.Int(1),
 						InstanceSizeSlug: pulumi.String("apps-s-1vcpu-0.5gb"),
-						Git: &digitalocean.AppSpecServiceGitArgs{
-							RepoCloneUrl: pulumi.String("https://github.com/holochain/wind-tunnel-runner-status-dashboard.git"),
-							Branch:       pulumi.String("main"),
+						Image: &digitalocean.AppSpecServiceImageArgs{
+							RegistryType: pulumi.String("GHCR"),
+							Registry:     pulumi.String("holochain"),
+							Repository:   pulumi.String("wind-tunnel-runner-status-dashboard"),
+							Tag:          pulumi.String("latest"),
 						},
-						DockerfilePath: pulumi.String("Dockerfile"),
 						HttpPort: pulumi.Int(3000),
 						Envs: digitalocean.AppSpecServiceEnvArray{
 							&digitalocean.AppSpecServiceEnvArgs{


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds, publishes the Docker image to GHCR, and triggers a DigitalOcean App Platform deployment on push to `main`
- Switches the DO app from Git-source to image-based deployment, pulling the `latest` tag from GHCR — ensuring the exact image validated in CI is what gets deployed
- Requires `DO_API_TOKEN` and `DO_APP_ID` secrets to be configured in the repo settings

Closes #14